### PR TITLE
Fix 'Change Device' to 'Select Device'

### DIFF
--- a/_docs/commands.md
+++ b/_docs/commands.md
@@ -57,7 +57,7 @@ This commands runs `flutter doctor` and shows the results in the `Output` pane.
 
 For more information on using packages [see the Flutter website](https://flutter.io/using-packages/).
 
-## Flutter: Change Device
+## Flutter: Select Device
 
 If you have multiple devices or simulators connected then this command will allow you to quickly switch between Dart SDKs. See [Quickly Switching Between Flutter Devices](/docs/quickly-switching-between-flutter-devices/) for more info.
 

--- a/_docs/quickly-switching-between-flutter-devices.md
+++ b/_docs/quickly-switching-between-flutter-devices.md
@@ -5,8 +5,8 @@ title: Quickly Switching Between Flutter Devices
 If you have multiple devices or simulators connected then there are a number of ways to quickly switch between them:
 
 1. Clicking on the currently selected device in the status bar
-1. Executing the [`Flutter: Change Device` command](/docs/commands/#flutter-change-device)
-1. Pressing your [custom key binding](/docs/commands/#keybinding-commands) for the [`Flutter: Change Device` command](/docs/commands/#flutter-change-device)
+1. Executing the [`Flutter: Select Device` command](/docs/commands/#flutter-change-device)
+1. Pressing your [custom key binding](/docs/commands/#keybinding-commands) for the [`Flutter: Select Device` command](/docs/commands/#flutter-change-device)
 
 You will be presented with a pick list of all devices and simulators to select from:
 


### PR DESCRIPTION
`changeDevice` command has been changed to `selectDevice` in https://github.com/Dart-Code/Dart-Code/commit/161871090f32895af53d7ade6f9b5dda848db8c2#diff-cb8bb9dc2e44317760d5e44e805e0df9